### PR TITLE
Chore/circleci config tweak

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -17,7 +17,7 @@ jobs:
             pip3 install docker-compose==1.20.1
       - run:
           name: Test
-          command: docker-compose run test
+          command: docker-compose up test
 
   deploy-dev:
     <<: *docker-defaults

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,10 +10,6 @@ services:
       - "3000:3000"
     env_file:
       - test.env
-    environment:
-      CI:
-      CODECLIMATE_REPO_TOKEN:
-      COVERALLS_REPO_TOKEN:
     command: ["/tmp/wait-for-it.sh", "db:5432", "--", "bundle", "exec", "rails", "server", "-b", "0.0.0.0"]
     depends_on:
       - setup_dbs
@@ -24,6 +20,10 @@ services:
       RAILS_ENV: test
     env_file:
       - test.env
+    environment:
+      CI:
+      CODECLIMATE_REPO_TOKEN:
+      COVERALLS_REPO_TOKEN:
     command: ["/tmp/wait-for-it.sh", "db:5432", "--", "bundle", "exec", "rake"]
     depends_on:
       - setup_test_dbs


### PR DESCRIPTION
@etgrieco these are leftover from an older implementation of circleci.

the CI env vars should be in the test container because that's the one run in CI